### PR TITLE
Create API for manifest ops

### DIFF
--- a/src/main/java/org/wildfly/prospero/extras/ProsperoExtras.java
+++ b/src/main/java/org/wildfly/prospero/extras/ProsperoExtras.java
@@ -1,0 +1,11 @@
+package org.wildfly.prospero.extras;
+
+import org.wildfly.prospero.extras.manifest.ManifestOperations;
+import org.wildfly.prospero.extras.manifest.ManifestOperationsFactory;
+
+public class ProsperoExtras {
+
+    public static ManifestOperations manifestOperations() {
+        return ManifestOperationsFactory.getNewInstance();
+    }
+}

--- a/src/main/java/org/wildfly/prospero/extras/manifest/ManifestOperations.java
+++ b/src/main/java/org/wildfly/prospero/extras/manifest/ManifestOperations.java
@@ -1,0 +1,39 @@
+package org.wildfly.prospero.extras.manifest;
+
+import org.wildfly.channel.ChannelManifest;
+import org.wildfly.installationmanager.ArtifactChange;
+import org.wildfly.prospero.extras.manifest.merge.VersionMergeStrategy;
+
+import java.util.List;
+
+public interface ManifestOperations {
+
+    /**
+     * Merges streams from two manifests.
+     *
+     * Creates a manifest containing streams from both input manifests. If the same stream is available in both input
+     * manifests, the conflict is resolved using a merge strategy.
+     * <ul>
+     *     <li>The LATEST merge strategy compares the versions and picks the latest stream.</li>
+     *     <li>The FIRST merge strategy chooses the stream from {@code manifestOne}.</li>
+     * </ul>
+     * @param manifestOne - first manifest to merge
+     * @param manifestTwo - second manifest to merge
+     * @param mergeStrategy - merging strategy used if the stream is found in both manifests
+     * @param mergedManifestName - optional name of the generated manifest
+     * @param mergedManifestId - optional id of the generated manifest
+     * @return - merged manifest
+     */
+    ChannelManifest merge(ChannelManifest manifestOne, ChannelManifest manifestTwo,
+                          VersionMergeStrategy.Strategies mergeStrategy,
+                          String mergedManifestName, String mergedManifestId);
+
+    /**
+     * Performs a diff of {@code manifestOne} and {@code manifestTwo}.
+     *
+     * @param manifestOne - first manifest to diff
+     * @param manifestTwo - second manifest to diff
+     * @return - list of changed streams representes as {@link ArtifactChange}s
+     */
+    List<ArtifactChange> diff(ChannelManifest manifestOne, ChannelManifest manifestTwo);
+}

--- a/src/main/java/org/wildfly/prospero/extras/manifest/ManifestOperationsFactory.java
+++ b/src/main/java/org/wildfly/prospero/extras/manifest/ManifestOperationsFactory.java
@@ -1,0 +1,8 @@
+package org.wildfly.prospero.extras.manifest;
+
+public abstract class ManifestOperationsFactory {
+
+    public static ManifestOperations getNewInstance() {
+        return new ManifestOperationsImpl();
+    }
+}

--- a/src/main/java/org/wildfly/prospero/extras/manifest/ManifestOperationsImpl.java
+++ b/src/main/java/org/wildfly/prospero/extras/manifest/ManifestOperationsImpl.java
@@ -1,0 +1,24 @@
+package org.wildfly.prospero.extras.manifest;
+
+import org.wildfly.channel.ChannelManifest;
+import org.wildfly.installationmanager.ArtifactChange;
+import org.wildfly.prospero.extras.manifest.diff.ManifestsDiffCommand;
+import org.wildfly.prospero.extras.manifest.merge.ManifestMergeCommand;
+import org.wildfly.prospero.extras.manifest.merge.VersionMergeStrategy;
+
+import java.util.List;
+
+class ManifestOperationsImpl implements ManifestOperations {
+
+    @Override
+    public ChannelManifest merge(ChannelManifest manifestOne, ChannelManifest manifestTwo,
+                                 VersionMergeStrategy.Strategies mergeStrategy,
+                                 String mergedManifestName, String mergedManifestId) {
+        return ManifestMergeCommand.merge(manifestOne, manifestTwo, mergeStrategy, mergedManifestName, mergedManifestId);
+    }
+
+    @Override
+    public List<ArtifactChange> diff(ChannelManifest manifestOne, ChannelManifest manifestTwo) {
+        return ManifestsDiffCommand.manifestDiff(manifestOne, manifestTwo);
+    }
+}

--- a/src/main/java/org/wildfly/prospero/extras/manifest/diff/ManifestsDiffCommand.java
+++ b/src/main/java/org/wildfly/prospero/extras/manifest/diff/ManifestsDiffCommand.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.Callable;
 
@@ -72,6 +73,9 @@ public class ManifestsDiffCommand implements Callable<Integer> {
     }
 
     public static List<ArtifactChange> manifestDiff(ChannelManifest manifestOne, ChannelManifest manifestTwo) {
+        Objects.requireNonNull(manifestOne);
+        Objects.requireNonNull(manifestTwo);
+
         Map<String, String> versionMapOne = streamToMap(manifestOne);
 
         Map<String, String> versionMapTwo = streamToMap(manifestTwo);

--- a/src/main/java/org/wildfly/prospero/extras/manifest/merge/ManifestMergeCommand.java
+++ b/src/main/java/org/wildfly/prospero/extras/manifest/merge/ManifestMergeCommand.java
@@ -3,11 +3,13 @@ package org.wildfly.prospero.extras.manifest.merge;
 import org.wildfly.channel.ChannelManifest;
 import org.wildfly.channel.ChannelManifestMapper;
 import org.wildfly.channel.Stream;
+import org.wildfly.prospero.extras.ReturnCodes;
 import picocli.CommandLine;
 
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
@@ -35,9 +37,22 @@ public class ManifestMergeCommand implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
-
         final ChannelManifest manifestOne = ChannelManifestMapper.from(this.manifestOne.toUri().toURL());
         final ChannelManifest manifestTwo = ChannelManifestMapper.from(this.manifestTwo.toUri().toURL());
+
+        final ChannelManifest mergedManifest = merge(manifestOne, manifestTwo, mergeStrategy, mergedManifestName, mergedManifestId);
+
+        System.out.println(ChannelManifestMapper.toYaml(mergedManifest));
+
+        return ReturnCodes.SUCCESS;
+    }
+
+    public static ChannelManifest merge(ChannelManifest manifestOne, ChannelManifest manifestTwo,
+                                        VersionMergeStrategy.Strategies mergeStrategy,
+                                        String mergedManifestName, String mergedManifestId) {
+        Objects.requireNonNull(manifestOne);
+        Objects.requireNonNull(manifestTwo);
+        Objects.requireNonNull(mergeStrategy);
 
         final Collection<Stream> streamsOne = manifestOne.getStreams();
         final Collection<Stream> streamsTwo = manifestTwo.getStreams();
@@ -58,9 +73,6 @@ public class ManifestMergeCommand implements Callable<Integer> {
             }
         }
 
-        final ChannelManifest mergedManifest = new ChannelManifest(mergedManifestName, mergedManifestId, null, merged);
-        System.out.println(ChannelManifestMapper.toYaml(mergedManifest));
-
-        return 0;
+        return new ChannelManifest(mergedManifestName, mergedManifestId, null, merged);
     }
 }

--- a/src/main/java/org/wildfly/prospero/extras/manifest/merge/VersionMergeStrategy.java
+++ b/src/main/java/org/wildfly/prospero/extras/manifest/merge/VersionMergeStrategy.java
@@ -2,7 +2,7 @@ package org.wildfly.prospero.extras.manifest.merge;
 
 import org.wildfly.channel.version.VersionMatcher;
 
-interface VersionMergeStrategy {
+public interface VersionMergeStrategy {
     enum Strategies implements VersionMergeStrategy {
         LATEST(new LatestMergeStrategy()),
         FIRST(new FirstMergeStrategy());


### PR DESCRIPTION
Example usage:

```
final ChannelManifest manifestOne = new ChannelManifest("manifest-one", null, null, 
        List.of(new Stream("org.test", "one", "1.0.0")));
final ChannelManifest manifestTwo = new ChannelManifest("manifest-two", null, null,
        List.of(new Stream("org.test", "two", "2.0.0")));

final ChannelManifest merged = ProsperoExtras.manifestOperations()
        .merge(manifestOne, manifestTwo, VersionMergeStrategy.Strategies.LATEST, "merged-manifest", "merge-123");
```
